### PR TITLE
Modifica URL radar precipitazioni

### DIFF
--- a/app/src/main/java/com/gmail/fattazzo/meteo/Config.kt
+++ b/app/src/main/java/com/gmail/fattazzo/meteo/Config.kt
@@ -65,7 +65,7 @@ object Config {
     const val PROJECTS_INFO_URL = "https://gist.githubusercontent.com/fattazzo/d6aa41128c39b4882c0b6bd232984cfb/raw/projetcs.json"
 
     // radar
-    const val RADAR_PRECIPITAZIONI = "https://content.meteotrentino.it/dati-meteo/radar/home/lastRadar4mobile.aspx"
+    const val RADAR_PRECIPITAZIONI = "https://content.meteotrentino.it/dati-meteo/radar/home/homepage.gif"
     const val RADAR_INFRAROSSI = "http://api.sat24.com/animated/ALPS/infraPolair/1/Central%20European%20Standard%20Time/493234"
     const val RADAR_NEVE = "https://api.sat24.com/animated/EU/snow/1/Central%20European%20Standard%20Time"
     const val RADAR_EUROPA = "https://api.sat24.com/animated/EU/infraPolair/1/Central%20European%20Standard%20Time"


### PR DESCRIPTION
La [GIF](https://content.meteotrentino.it/dati-meteo/radar/home/lastRadar4mobile.aspx) attualmente utilizzata nell'applicazione non viene aggiornata dal 07/05.
Ho quindi controllato il sito di Meteo Trentino ed ho scoperto che il sito mobile usa un altro [URL](https://content.meteotrentino.it/dati-meteo/radar/home/homepage.gif), tuttora aggiornato.